### PR TITLE
Add ability to use refresh token if the original one expires

### DIFF
--- a/AppCode/app/api/auth.js
+++ b/AppCode/app/api/auth.js
@@ -6,6 +6,7 @@ const headers =  {
 const signupEndpoint = '/auth/signup';
 const loginEndpoint = '/auth/login';
 const pwdResetEndpoint = '/auth/forgotPwd';
+const tokenRefreshEndpoint = '/auth/tokenRefresh';
 
 const signup = (input) => client.post(signupEndpoint, input, {headers: headers});
 
@@ -13,8 +14,22 @@ const login = (input) => client.post(loginEndpoint, input, {headers: headers});
 
 const pwdReset = (input) => client.post(pwdResetEndpoint, input, {headers: headers});
 
+const tokenRefresh = (input) => {
+    const headers =
+    {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${input}`,
+    };
+
+    client.setHeaders(headers);
+    const response = client.post(tokenRefreshEndpoint);
+
+    return response;
+}
+
 export {
     signup,
     login,
-    pwdReset
+    pwdReset,
+    tokenRefresh
 }

--- a/AppCode/app/api/status.js
+++ b/AppCode/app/api/status.js
@@ -1,4 +1,5 @@
 import client from "./client";
+import logOut from "../auth/useAuth"
 import authStorage from "../auth/storage";
 
 const endpointGetStatus = "/activity/getStatus";
@@ -6,6 +7,9 @@ const endpointUpdateStatus = "/activity/updateStatus";
 
 const getActivityStatus = async () => {
   const token = await authStorage.getToken();
+  if (token == null) {
+    return null;
+  }
 
   client.setHeaders({
     "Content-Type": "application/json",
@@ -18,6 +22,9 @@ const getActivityStatus = async () => {
 
 const updateActivityStatus = async (data) => {
   const token = await authStorage.getToken();
+  if (token == null) {
+    return null;
+  }
 
   client.setHeaders({
     "Content-Type": "application/json",

--- a/AppCode/app/auth/storage.js
+++ b/AppCode/app/auth/storage.js
@@ -1,35 +1,107 @@
 import * as SecureStore from "expo-secure-store";
 import jwtDecode from "jwt-decode";
+import { tokenRefresh } from "../api/auth";
 
-const key = "authToken";
+const authKey = "authToken";
+const refreshKey = "refreshToken";
 
 const storeToken = async (authToken) => {
   try {
-    await SecureStore.setItemAsync(key, authToken);
+    await SecureStore.setItemAsync(authKey, authToken);
   } catch (error) {
     console.log("Error storing the auth token", error);
   }
 };
 
-const getToken = async () => {
+const getAuthToken = async () => {
   try {
-    return await SecureStore.getItemAsync(key);
+    return await SecureStore.getItemAsync(authKey);
   } catch (error) {
     console.log("Error getting the auth token", error);
   }
 };
 
+const getToken = async () => {
+  try {
+    const accessToken = await getAuthToken();
+
+    // If current CRUD acces token expired, renew it using refresh token
+    if (tokenExpired(accessToken)) {
+
+      const refresh_token = await getRefreshToken();
+
+      try {
+        // Check refresh token is not expired, otherwise return null to indicate requiring a re-login
+        if (tokenExpired(refresh_token)) {
+          console.log("User need to login again");
+          return null;
+        }
+        const response = await tokenRefresh(refresh_token);
+        const newToken = response.data.token;
+
+        // Once the "refreshed" token is retrieved, store it for future API calls
+        storeToken(newToken);
+
+        return newToken;
+      } catch (error) {
+        console.log("Error renewing the auth token", error)
+        return null;
+      }
+    } else {
+      return accessToken;
+    }
+  } catch (error) {
+    console.log("Error getting the valid token", error);
+    return null;
+  }
+};
+
 const getUser = async () => {
-  const token = await getToken();
+  const token = await getAuthToken();
   return token ? JSON.parse(jwtDecode(token).sub) : null;
 };
 
 const removeToken = async () => {
   try {
-    await SecureStore.deleteItemAsync(key);
+    await SecureStore.deleteItemAsync(authKey);
   } catch (error) {
     console.log("Error removing the auth token", error);
   }
 };
 
-export default { getUser, getToken, storeToken, removeToken };
+const getRefreshToken = async () => {
+  try {
+    const refreshToken = await SecureStore.getItemAsync(refreshKey);
+    return refreshToken;
+  } catch (error) {
+    console.log("Error getting the refresh token", error);
+  }
+};
+
+const removeRefreshToken = async () => {
+  try {
+    await SecureStore.deleteItemAsync(refreshKey);
+  } catch (error) {
+    console.log("Error removing the refresh token", error);
+  }
+};
+
+const storeRefreshToken = async (refresh_token) => {
+  try {
+    await SecureStore.setItemAsync(refreshKey, refresh_token);
+  } catch (error) {
+    console.log("Error storing the refresh token", error);
+  }
+};
+
+const tokenExpired = (token) => {
+  const exp = jwtDecode(token).exp;
+
+  const now = Date.now() / 1000;
+
+  return (now > exp ? true : false);
+
+
+}
+
+export default { getUser, getToken, storeToken, storeRefreshToken, removeToken, removeRefreshToken };

--- a/AppCode/app/auth/useAuth.js
+++ b/AppCode/app/auth/useAuth.js
@@ -7,16 +7,22 @@ import authStorage from './storage';
 export default useAuth = () => {
     const { user, setUser } = useContext(AuthContext);
 
-    const logIn = (authToken) => {
+    const logIn = (data) => {
+
+        const authToken = data.token;
+        const refresh_token = data.refresh_token;
+
         const user = JSON.parse(jwtDecode(authToken).sub);
         console.log(user);
         setUser(user);
         authStorage.storeToken(authToken);
+        authStorage.storeRefreshToken(refresh_token);
     };
 
     const logOut = () => {
         setUser(null);
         authStorage.removeToken();
+        authStorage.removeRefreshToken();
     };
 
     return { user, logIn, logOut };

--- a/AppCode/app/config/uistrings.js
+++ b/AppCode/app/config/uistrings.js
@@ -26,6 +26,7 @@ export default {
     PrivacyPolicyText: "Privacy policy text Privacy policy text Privacy policy text Privacy policy text Privacy policy text Privacy policy text Privacy policy text Privacy policy text Privacy policy text Privacy policy text",
     Recover: "Recover",
     Recovery: "recovery",
+    RequireRelogin: "Your access has been expired and require to login in using user name and password again",
     Send: "Send",
     SendMessage: "Send Message",
     SendMessageToMAL: "Send a message to Music As Language",

--- a/AppCode/app/screens/HomeScreen.js
+++ b/AppCode/app/screens/HomeScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState, useEffect, useRef } from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import { Alert, FlatList, StyleSheet, View } from 'react-native';
 import { Video } from "expo-av";
 
 import AppText from "../components/AppText";
@@ -10,6 +10,8 @@ import colors from '../config/colors';
 import getLessons from '../api/lessons';
 import routes from '../navigation/routes';
 import ListItemSeparator from "../components/ListItemSeparator";
+import useAuth from "../auth/useAuth";
+import uistrings from '../config/uistrings';
 import { getActivityStatus } from "../api/status";
 
 function HomeScreen({ navigation }) {
@@ -17,6 +19,7 @@ function HomeScreen({ navigation }) {
     const [lessons, setLessons] = useState([]);
     const player = useRef(null);
     const [activityStatus, setActivityStatus] = useState();
+  const { logOut } = useAuth();
 
     useEffect(() => {
         let mounted = true;
@@ -41,8 +44,18 @@ function HomeScreen({ navigation }) {
     useEffect(() => {
       const focus = navigation.addListener("focus", () => {
         getActivityStatus().then((response) => {
-          const data = response.data;
-          setActivityStatus(data);
+          if (response == null) {
+            const reloginAlert = () => {
+              Alert.alert(uistrings.Messages, uistrings.RequireRelogin, [
+                { text: "OK", onPress: () => logOut() }
+              ])
+            };
+
+            reloginAlert();
+          } else {
+            const data = response.data;
+            setActivityStatus(data);
+          }
         });
       });
 

--- a/AppCode/app/screens/LessonDetailsScreen.js
+++ b/AppCode/app/screens/LessonDetailsScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { SafeAreaView, View, FlatList, StyleSheet } from "react-native";
+import { SafeAreaView, View, FlatList, StyleSheet, Alert } from "react-native";
 import { Video } from "expo-av";
 
 import AppText from "../components/AppText";
@@ -11,11 +11,13 @@ import BackButton from "../components/BackButton";
 import Screen from "../components/Screen";
 import Icon from "../components/Icon";
 import uistrings from "../config/uistrings";
-
+import useAuth from "../auth/useAuth";
 import { getActivityStatus } from "../api/status";
+
 
 function LessonDetailsScreen({ navigation, route }) {
   const lesson = route.params;
+  const { logOut } = useAuth();
 
   // Need to pause the video when navigate away to a new screen
   const player = useRef(null);
@@ -34,8 +36,18 @@ function LessonDetailsScreen({ navigation, route }) {
       // Workaround to delay GET call so the POST call happens first
       setTimeout(() => {
         getActivityStatus().then((response) => {
-          const data = response.data;
-          setActivityStatus(data);
+          if (response == null) {
+            const reloginAlert = () => {
+              Alert.alert(uistrings.Messages, uistrings.RequireRelogin, [
+                { text: "OK", onPress: () => logOut() }
+              ])
+            };
+
+            reloginAlert();
+          } else {
+            const data = response.data;
+            setActivityStatus(data);
+          }
         });
       }, 100);
     });

--- a/AppCode/app/screens/LoginScreen.js
+++ b/AppCode/app/screens/LoginScreen.js
@@ -25,7 +25,7 @@ function LoginScreen({ navigation }) {
         const result = await login(userInfo);
         if (!result.ok) return setLoginFailed(true);
         setLoginFailed(false);
-        logIn(result.data.token);
+        logIn(result.data);
     };
     
     return (


### PR DESCRIPTION
1) Create a new authentication key using refresh token when the original one expires;
2) If the refresh token expires also, prompt customers to login again
3) This is done for Home Screen and Activity Screen whenever API calls were made

NOTE:
Tested the code locally by modifying expiration date of auth token to be less than one minute.