### PR TITLE
Fix the issue where sign up will cause an error due to missing refresh_token

### DIFF
--- a/AppCode/app/screens/RegisterScreen.js
+++ b/AppCode/app/screens/RegisterScreen.js
@@ -39,7 +39,7 @@ function RegisterScreen({ navigation }) {
         };
         const loginResult = await login(loginInfo);
         if (!loginResult.ok) setError("Login failed. Please try again later.");
-        auth.logIn(loginResult.data.token);
+        auth.logIn(loginResult.data);
     };
 
     return (


### PR DESCRIPTION
Fix for  #41 .

Fix the issue of refresh_token not being passed to Login call when a new account is being created (i.e. Sign Up path)