### PR TITLE
Add Scoring for Songs

### DIFF
--- a/AppCode/App.js
+++ b/AppCode/App.js
@@ -9,12 +9,14 @@ import AuthContext from "./app/auth/context";
 import authStorage from "./app/auth/storage";
 import LessonContext from "./app/data/lesson/lessoncontext";
 import RewardContext from "./app/data/config/rewardcontext";
+import SongContext from "./app/data/song/songcontext";
 
 export default function App() {
   const [user, setUser] = useState();
   const [status, setStatus] = useState();
   const [playStateChanged, setPlayStateChanged] = useState();
   const [rewardConfig, setRewardConfig] = useState();
+  const [songStatus, setSongStatus] = useState();
 
   const restoreUser = async () => {
     const user = await authStorage.getUser();
@@ -31,9 +33,11 @@ export default function App() {
         value={{ status, setStatus, playStateChanged, setPlayStateChanged }}
       >
         <RewardContext.Provider value={{ rewardConfig, setRewardConfig }}>
-          <NavigationContainer theme={navigationTheme}>
-            {user ? <AppNavigator /> : <AuthNavigator />}
-          </NavigationContainer>
+          <SongContext.Provider value={{ songStatus, setSongStatus }}>
+            <NavigationContainer theme={navigationTheme}>
+              {user ? <AppNavigator /> : <AuthNavigator />}
+            </NavigationContainer>
+          </SongContext.Provider>
         </RewardContext.Provider>
       </LessonContext.Provider>
     </AuthContext.Provider>

--- a/AppCode/app/api/status.js
+++ b/AppCode/app/api/status.js
@@ -2,8 +2,11 @@ import client from "./client";
 import logOut from "../auth/useAuth"
 import authStorage from "../auth/storage";
 
-const endpointGetStatus = "/activity/getStatus";
-const endpointUpdateStatus = "/activity/updateStatus";
+const endpointGetActivityStatus = "/activity/getStatus";
+const endpointUpdateActivityStatus = "/activity/updateStatus";
+
+const endpointGetSongPlayingStatus = "/activity/getSongPlayingStatus";
+const endpointUpdateSongPlayingStatus = "/activity/updateSongPlayingStatus";
 
 const getActivityStatus = async () => {
   const token = await authStorage.getToken();
@@ -16,7 +19,7 @@ const getActivityStatus = async () => {
     Authorization: `Bearer ${token}`,
   });
 
-  const response = await client.get(endpointGetStatus);
+  const response = await client.get(endpointGetActivityStatus);
   return response;
 };
 
@@ -31,8 +34,38 @@ const updateActivityStatus = async (data) => {
     Authorization: `Bearer ${token}`,
   });
 
-  const response = await client.post(endpointUpdateStatus, data);
+  const response = await client.post(endpointUpdateActivityStatus, data);
   return response;
 };
 
-export { getActivityStatus, updateActivityStatus };
+const getSongPlayingStatus = async () => {
+  const token = await authStorage.getToken();
+  if (token == null) {
+    return null;
+  }
+
+  client.setHeaders({
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  });
+
+  const response = await client.get(endpointGetSongPlayingStatus);
+  return response;
+};
+
+const updateSongPlayingStatus = async (data) => {
+  const token = await authStorage.getToken();
+  if (token == null) {
+    return null;
+  }
+
+  client.setHeaders({
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  });
+
+  const response = await client.post(endpointUpdateSongPlayingStatus, data);
+  return response;
+};
+
+export { getActivityStatus, updateActivityStatus, getSongPlayingStatus, updateSongPlayingStatus };

--- a/AppCode/app/components/SongListItem.js
+++ b/AppCode/app/components/SongListItem.js
@@ -39,7 +39,8 @@ function SongListItem({
     length,
     onPress,
     isPlaying,
-    activeListItem})
+    activeListItem,
+    repeats})
     {
     return (
         <TouchableHighlight underlayColor={colors.white} onPress={onPress}>
@@ -56,8 +57,8 @@ function SongListItem({
                         <Text numberOfLines={1} style={styles.title}>
                             {songName}
                         </Text>
-                        <Text style={styles.singer}>
-                            Bernadette Bascom
+                        <Text style={styles.completions}>
+                            Completions: {repeats}
                         </Text>
                     </View>
                 </View>
@@ -73,6 +74,10 @@ function SongListItem({
 
 const {width} = Dimensions.get('window');
 const styles = StyleSheet.create({
+    completions: {
+        fontSize: 12,
+        color: colors.grey,
+    },
     container: {
         flexDirection: "row",
         alignSelf: "center",
@@ -111,10 +116,6 @@ const styles = StyleSheet.create({
     title: {
         fontSize: 18,
         color: colors.black,
-    },
-    singer: {
-        fontSize: 12,
-        color: colors.grey,
     },
     musicLength: {
         fontSize: 15,

--- a/AppCode/app/data/config/reward.js
+++ b/AppCode/app/data/config/reward.js
@@ -25,6 +25,15 @@ export default useRewardConfig = () => {
     }
   };
 
+  const getSongRepeatPoint = async () => {
+    if (rewardConfig == undefined) {
+      const response = await getLessons();
+      return response.data[0].RewardConfig.SongRepeat;
+    } else {
+      return rewardConfig.SongRepeat;
+    }
+  };
+ 
   const getTrophies = async () => {
     if (rewardConfig === undefined) {
       const response = await getLessons();
@@ -34,5 +43,5 @@ export default useRewardConfig = () => {
     }
   };
 
-  return { getActivityRepeatPoint, getRewardConfig, getTrophies, rewardConfig };
+  return { getActivityRepeatPoint, getSongRepeatPoint, getRewardConfig, getTrophies, rewardConfig };
 };

--- a/AppCode/app/data/song/songcontext.js
+++ b/AppCode/app/data/song/songcontext.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const SongContext = React.createContext();
+
+export default SongContext;

--- a/AppCode/app/data/song/songdata.js
+++ b/AppCode/app/data/song/songdata.js
@@ -1,0 +1,64 @@
+import SongContext from "./songcontext";
+import { useContext } from "react";
+import { getSongPlayingStatus, updateSongPlayingStatus } from "../../api/status";
+
+export default useSong = () => {
+    const { songStatus, setSongStatus } = useContext(SongContext);
+
+    //
+    // Purpose: Retrieve the specified song repeat count for a given song
+    // Return: a number
+    //
+    const getSongRepeats = (songName) => {
+        try {
+            let repeats = 0;
+
+            if (songStatus == undefined) return;
+
+            const song = songStatus.filter(
+                (item) => item.SongName == songName
+            );
+
+            repeats = song[0]?.Repeats == null ? 0: song[0].Repeats;
+            return repeats;
+        } catch (error) {
+            console.log(error);
+        }
+    };
+
+    //
+    // Purpose: fetch all song progress data from server (HTTPS GET)
+    // Return: response object from server endpoint
+    //
+    const fetchStatusData = async () => {
+        const response = await getSongPlayingStatus();
+
+        if (response === null) {
+            return null;
+        } else {
+            setSongStatus(response.data);
+            return response;
+        }
+    };
+
+    // 
+    // Purpose: Post song progress data to server (HTTPS POST)
+    // Return: response object from server endpoint
+    //
+    const updateStatusData = async (data) => {
+        const response = await updateSongPlayingStatus(data);
+
+        if (response === null) {
+            return null;
+        } else {
+            return response;
+        }
+    };
+
+    return {
+        songStatus,
+        fetchStatusData,
+        updateStatusData,
+        getSongRepeats,
+    };
+};

--- a/AppCode/app/screens/SongListScreen.js
+++ b/AppCode/app/screens/SongListScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, View, FlatList } from 'react-native';
+import { Alert, FlatList, StyleSheet, View } from 'react-native';
 import {Audio} from 'expo-av';
 
 import Screen from '../components/Screen';
@@ -10,10 +10,17 @@ import BackButton from "../components/BackButton";
 import SongListItem from "../components/SongListItem";
 import getLessons from '../api/lessons';
 import routes from "../navigation/routes";
+import useAuth from '../auth/useAuth';
+import ScoreNotification from "../components/ScoreNotification";
+import useRewardConfig from "../data/config/reward";
+import useSong from "../data/song/songdata";
 import { play, pause, resume, playNext } from '../media_control/audioController';
 
 function SongListScreen({ navigation, route }) {
     const songCategory = route.params;
+
+    const { fetchStatusData, getSongRepeats, updateStatusData } = useSong();
+    const { logOut } = useAuth();
 
     const [songs, setSongs] = useState([]);
     const [playbackObj, setPlaybackObj] = useState(null);
@@ -21,6 +28,13 @@ function SongListScreen({ navigation, route }) {
     const [currenAudio, setCurrenAudio] = useState({});
     const [isPlaying, setIsPlaying] = useState(false);
     const [currentAudioIndex, setCurrentAudioIndex] = useState(null);
+    const [repeatPoint, setRepeatPoint] = useState(0);
+    const [score, setScore] = useState(0);
+    const [playCount, setPlayCount] = useState(0);
+    const [songFullScore, setSongFullScore] = useState(0);
+    const [songJustFinish, setSongJustFinish] = useState(false);
+
+    const { getSongRepeatPoint } = useRewardConfig();
 
     Audio.setAudioModeAsync({
         playsInSilentModeIOS: true,
@@ -28,6 +42,7 @@ function SongListScreen({ navigation, route }) {
 
     useEffect(() => {
         let mounted = true;
+
         getLessons()
             .then(response => {
                 if (mounted) {
@@ -35,7 +50,33 @@ function SongListScreen({ navigation, route }) {
                     let filteredSongList = songList.filter((song) => song.Category === songCategory)
                     setSongs(filteredSongList)
                 }
-            })
+            });
+
+        getSongRepeatPoint()
+            .then(response => {
+                if (mounted) {
+                    if (response) {
+                        const repeatPoint = response;
+                        setRepeatPoint(repeatPoint);
+                    }
+                }
+            });
+
+        setTimeout(() => {
+            fetchStatusData()
+                .then(response => {
+                    if (response == null) {
+                        const reloginAlert = () => {
+                            Alert.alert(uistrings.Messages, uistrings.RequireRelogin, [
+                                { text: uistrings.OK, onPress: () => logOut() },
+                            ]);
+                        };
+                    } else {
+                        console.log("Song status data refreshed.")
+                    }
+                });
+        }, 300);
+
         return () => mounted = false;
     }, []);
 
@@ -51,10 +92,66 @@ function SongListScreen({ navigation, route }) {
         return unsubscribe;
     }, [navigation, soundObj, playbackObj, isPlaying]);
 
+    useEffect(() => {
+        // update current playing song's playcount and full score.
+        if (currenAudio.Name !== null){
+            setSongFullScore(currenAudio.Score);
+            const previousPlayCount = getSongRepeats(currenAudio.Name);
+            setPlayCount(previousPlayCount);
+        }
+    }, [currenAudio]);
+
+    useEffect(() => {
+        // everytime the playCount change, we upload the song play data to server, and then fetch new status data
+        if (currenAudio.Name !== null) {
+            const data = {
+                SongName: currenAudio.Name,
+                Category: songCategory,
+                CompletionStatus: 10,
+                Repeats: playCount,
+            };
+            console.log(data);
+            updateStatusData(data).then((response) => {
+                if (response == null) {
+                    console.warn(response);
+                }
+            });
+
+            setTimeout(() => {
+                fetchStatusData()
+                    .then(response => {
+                        if (response == null) {
+                            const reloginAlert = () => {
+                                Alert.alert(uistrings.Messages, uistrings.RequireRelogin, [
+                                    { text: uistrings.OK, onPress: () => logOut() },
+                                ]);
+                            };
+                        } else {
+                            console.log("Song status data refreshed.")
+                        }
+                    });
+            }, 300);
+        }
+    }, [playCount]);
+
+    useEffect(() => {
+        // If song just finish, update score and playcount, then set songJustFinish back to false.
+        if (songJustFinish === true) {
+            if (playCount === 0){
+                setScore(songFullScore);
+            } else {
+                setScore(songFullScore * repeatPoint);
+            }
+            setPlayCount(playCount + 1);
+            setSongJustFinish(false);
+        }
+    }, [songJustFinish]);
+
     const onPlaybackStatusUpdate = playbackStatus => {
-        if (playbackStatus.didJustFinish && !playbackStatus.isLooping) {
+        if (playbackStatus.didJustFinish) {
             setIsPlaying(false);
-            return setSoundObj(null);
+            setSoundObj(null);
+            return setSongJustFinish(true);
         }
     };
 
@@ -98,12 +195,15 @@ function SongListScreen({ navigation, route }) {
     };
 
     const renderItem = (item) => {
+        const repeats = getSongRepeats(item.Name);
+
         return (
           <SongListItem
             songName={item.Name}
             isPlaying={isPlaying}
             activeListItem={item._id === currentAudioIndex}
             length={item.LengthInSeconds}
+            repeats={repeats}
             onPress={() => handleAudioPress(item)}
           />
         );


### PR DESCRIPTION
- Show number of completions of each song under the song name (see pic). After finishing a song, update new song repeats to server and then pull new song status data. The number of completions will be updated.
- Update user's total score after playing a song. No congratulation pop-up for now, to be less interrupting (to be decided later). The total score under Profile screen will be updated then.
<img width="343" alt="Screen Shot 2022-08-03 at 2 20 10 PM" src="https://user-images.githubusercontent.com/75764452/182715425-e6f1da5b-1165-46c9-b8ff-b824f9c811c5.png">

