### PR TITLE
Fixing the issue where audio becomes low after accessing an lesson activity

### DIFF
--- a/AppCode/app/screens/ActivityDetailsScreen.js
+++ b/AppCode/app/screens/ActivityDetailsScreen.js
@@ -102,8 +102,6 @@ function ActivityScreen({ navigation, route }) {
 
   Audio.setAudioModeAsync({
     playsInSilentModeIOS: true,
-    allowsRecordingIOS: true,
-    interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
   });
 
   useEffect(() => {
@@ -361,6 +359,12 @@ function ActivityScreen({ navigation, route }) {
 
   const recordVideo = async () => {
     if (cameraRef) {
+      Audio.setAudioModeAsync({
+        playsInSilentModeIOS: true,
+        allowsRecordingIOS: true,
+        interruptionModeIOS: Audio.INTERRUPTION_MODE_IOS_DO_NOT_MIX,
+      });
+
       let video = await cameraRef.recordAsync({});
       //console.log("recordVideo ", video.uri);
 
@@ -376,6 +380,13 @@ function ActivityScreen({ navigation, route }) {
   const stopRecord = async () => {
     try {
       await cameraRef.stopRecording();
+
+      // resetting the AudioMode
+      // this is to fix the issue where audio becoomes lower
+      // after came into practice mode
+      Audio.setAudioModeAsync({
+        playsInSilentModeIOS: true,
+      });
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
This is to address issue #177. It was fixed by moving the call to set allowsRecordingIOS to before & after recording instead of beginning.

Tested the change by playing an activity, verify the sound level before & after opening it is the same; can record in practice mode with no issue with sound.